### PR TITLE
pass domain/workgroup to creds & fix SmbFileAttributes#isDirectory behaviour for root folder/share

### DIFF
--- a/src/main/java/com/github/jfrommann/nio/smb/SmbFileAttributes.java
+++ b/src/main/java/com/github/jfrommann/nio/smb/SmbFileAttributes.java
@@ -8,10 +8,6 @@ import java.nio.file.attribute.FileTime;
 import java.util.concurrent.TimeUnit;
 
 public final class SmbFileAttributes implements BasicFileAttributes {
-    /**
-     * nteger value encoding the resource attributes.
-     */
-    private final int attributes;
 
     /**
      * Unix timestamp of the creation date.
@@ -33,6 +29,10 @@ public final class SmbFileAttributes implements BasicFileAttributes {
      */
     private final int code;
 
+    private final boolean isDirectory;
+
+    private final boolean isRegularFile;
+
     /**
      * Public default constructor for {@link SmbFileAttributes}.
      *
@@ -50,11 +50,12 @@ public final class SmbFileAttributes implements BasicFileAttributes {
      * @throws IOException If something goes wrong while accessing the file.
      */
     SmbFileAttributes(SmbFile file) throws IOException {
-        this.attributes = file.getAttributes();
         this.created = file.createTime();
         this.modified = file.lastModified();
         this.length = file.length();
         this.code = file.hashCode();
+        this.isDirectory = file.isDirectory();
+        this.isRegularFile = file.isFile();
     }
 
     @Override
@@ -74,12 +75,12 @@ public final class SmbFileAttributes implements BasicFileAttributes {
 
     @Override
     public boolean isRegularFile() {
-        return (this.attributes & SmbFile.ATTR_DIRECTORY) == 0;
+        return this.isRegularFile;
     }
 
     @Override
     public boolean isDirectory() {
-        return (this.attributes & SmbFile.ATTR_DIRECTORY) != 0;
+        return this.isDirectory;
     }
 
     @Override

--- a/src/main/java/com/github/jfrommann/nio/smb/SmbFileSystemProvider.java
+++ b/src/main/java/com/github/jfrommann/nio/smb/SmbFileSystemProvider.java
@@ -11,7 +11,7 @@ import jcifs.context.AbstractCIFSContext;
 import jcifs.context.BaseContext;
 import jcifs.context.CIFSContextCredentialWrapper;
 import jcifs.context.SingletonContext;
-import jcifs.smb.NtlmPasswordAuthentication;
+import jcifs.smb.NtlmPasswordAuthenticator;
 import jcifs.smb.SmbFile;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -258,9 +258,13 @@ public final class SmbFileSystemProvider extends FileSystemProvider {
             return context;
         }
         final String domainAndUser = StringUtils.substringBefore(authority, "@");
-        final String userInfo = domainAndUser.contains(";") ? StringUtils.substringAfter(domainAndUser, ";") : domainAndUser;
+        final boolean hasDomain = domainAndUser.contains(";");
+        final String userInfo = hasDomain ? StringUtils.substringAfter(domainAndUser, ";") : domainAndUser;
+        final String user = StringUtils.substringBefore(userInfo, ":");
+        final String password = StringUtils.substringAfter(userInfo, ":");
+        final String domain = hasDomain ? StringUtils.substringBefore(domainAndUser, ";") : null;
         return (StringUtils.isNotEmpty(userInfo)) ?
-                new CIFSContextCredentialWrapper((AbstractCIFSContext) context, new NtlmPasswordAuthentication(context, userInfo)) : context;
+                new CIFSContextCredentialWrapper((AbstractCIFSContext) context, new NtlmPasswordAuthenticator(domain, user, password)) : context;
     }
 
     /**


### PR DESCRIPTION
This PR contains 2 small fixes:

[pass domain/workgroup to creds](https://github.com/jfrommann/smb-nio-ng/commit/c503331725729c61b5f767336c11e3896846a3b9) 

Also replaced deprecated NtlmPasswordAuthentication
with NtlmPasswordAuthenticator
 
[Fix SmbFileAttributes#isDirectory behaviour for root folder/share](https://github.com/jfrommann/smb-nio-ng/commit/346f9b94ebb2ab90a20551b1b149938568557f5d) 

Previously SmbFileAttributes isDirectory would return false
for root directory/share but SmbFile#isDirectory would return true.

Just use the SmbFile#isDirectory directly since it has handling
for the root directory/share scenario